### PR TITLE
Add missing <! in list case of awalk

### DIFF
--- a/src/jtk_dvlp/async.cljc
+++ b/src/jtk_dvlp/async.cljc
@@ -183,7 +183,7 @@
   (go
     (cond
       (list? form)
-      (<outer (apply list (<! (amap <inner form))))
+      (<! (<outer (apply list (<! (amap <inner form)))))
 
       #?(:cljs (map-entry? form) :clj (instance? clojure.lang.IMapEntry form))
       (do


### PR DESCRIPTION
Looks like the `list?` case in `awalk` is missing an outer `<!`.

Alternately, there's a case to do a bit more refactoring and pull the `<!`  (and optionally even the `<outer`) out of the `cond`, which would also fix this.  

For example, something like 

```clojure
(go
  (<! 
    (<outer
      (cond ...))))
```

I'm happy to write it up either way if you like, or of course you're welcome to close this and fix it in the style of your choosing.